### PR TITLE
fix: Resolve parameter mismatch issue in vocabulary key activation

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -1,0 +1,4 @@
+# Features
+
+# Fixes
+- Fix unable to enrich data

--- a/src/ExternalSearch.Providers.DuckDuckgo/Services/VocabularyService.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/Services/VocabularyService.cs
@@ -50,14 +50,14 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckgo.Services
         {
             var vocabRepository = GetVocabularyRepository(context);
             var activateVocab = vocabRepository.GetType().GetMethod("ActivateVocabulary");
-            return (Task)activateVocab.Invoke(vocabRepository, new object[] { vocabularyId });
+            return (Task)activateVocab.Invoke(vocabRepository, new object[] { context, vocabularyId });
         }
 
         public Task ActivateVocabularyKey(ExecutionContext context, Guid vocabularyKeyId)
         {
             var vocabRepository = GetVocabularyRepository(context);
             var activateVocabKey = vocabRepository.GetType().GetMethod("ActivateVocabularyKey");
-            return (Task)activateVocabKey.Invoke(vocabRepository, new object[] { vocabularyKeyId });
+            return (Task)activateVocabKey.Invoke(vocabRepository, new object[] { context, vocabularyKeyId });
         }
 
         private object GetVocabularyRepository(ExecutionContext context)


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#45211](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/45211)

Might need to change the ActivateVocabularyKey() and ActivateVocabulary() to the private service

## How has it been tested? <!-- Remove if not needed -->
Manually in local

