### PR TITLE
fix: Reduce exceptions thrown when throttled

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -4,3 +4,4 @@
 # Fixes
 - Unable to enrich due to create vocabulary method parameter mismatch
 - Fix Topology not showing data from enricher
+- Reduce exceptions thrown when throttled by DuckDuckGo

--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,2 +1,0 @@
-# Fixes
-- Reduce exceptions thrown when throttled by DuckDuckGo

--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+# Fixes
+- Reduce exceptions thrown when throttled by DuckDuckGo

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -508,7 +508,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             var request = new RestRequest($"?{queryParameters}", method);
 
             var applicationRateLimitService = context.ApplicationContext.Container.Resolve<IApplicationRateLimitingService>();
-            applicationRateLimitService.ThrottleProcessAsync(context, "DuckDuckGo_Throttling", TimeSpan.FromSeconds(1), 2, 1000).GetAwaiter().GetResult();
+            applicationRateLimitService.ThrottleClusterAsync(context, "DuckDuckGo_Throttling", TimeSpan.FromSeconds(1), 5, 1000).GetAwaiter().GetResult();
 
             var response = client.Execute(request);
 
@@ -534,7 +534,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
                 context.Log.LogDebug($"DuckDuckGo returned empty infobox for {name}");
 
-                if (response.StatusCode != HttpStatusCode.Accepted) return responseData;
+                if (response.StatusCode != HttpStatusCode.Accepted && response.StatusCode != HttpStatusCode.TooManyRequests) return responseData;
 
                 throw new ApplicationException($"Too many requests - Could not execute external search query - StatusCode:{response.StatusCode}; Content: {content}");
             }

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -33,7 +33,9 @@ using Newtonsoft.Json;
 using RestSharp;
 using System.Web;
 using System.Text.RegularExpressions;
+using CluedIn.Core.RateLimiting;
 using CluedIn.Integration.PrivateServices.Vocabularies;
+using Microsoft.Extensions.Logging;
 
 namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 {
@@ -109,7 +111,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             var existingResults = request.GetQueryResults<SearchResult>(this).Where(r => r.Data.Infobox != null).ToList();
 
-            Func<string, bool> existingResultsFilter    = value => existingResults.SafeEnumerate().Any(r => string.Equals(r.Data.Infobox.Meta.First().Value, value, StringComparison.InvariantCultureIgnoreCase));
+            Func<string, bool> existingResultsFilter    = value => existingResults.SafeEnumerate().Any(r => string.Equals(r.Data.Infobox.Meta?.FirstOrDefault()?.Value, value, StringComparison.InvariantCultureIgnoreCase));
             Func<string, bool> existingResultsFilter2   = value => existingResults.SafeEnumerate().Any(r => r.Data.Results.SafeEnumerate().Any(v => v.FirstURL.Contains(value)));
             Func<string, bool> nameFilter               = value => OrganizationFilters.NameFilter(context, value);
 
@@ -184,7 +186,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             foreach (var searchName in GetSearchVariants(name.Trim()))
             {
-                var responseData = JsonRequestWrapper(client, searchName, Method.GET);
+                var responseData = JsonRequestWrapper(context, client, searchName, Method.GET);
 
                 if (responseData?.Infobox == null) continue;
 
@@ -496,7 +498,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
         /// <summary>
         /// Wrapper around a request to ensure proper deserialization of the JSON.
         /// </summary>
-        private static SearchResult JsonRequestWrapper(IRestClient client, string name, Method method)
+        private static SearchResult JsonRequestWrapper(ExecutionContext context, IRestClient client, string name, Method method)
         {
             var queryParameters = HttpUtility.ParseQueryString("");
             queryParameters.Add("q", name);
@@ -504,6 +506,10 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             queryParameters.Add("timestamp", DateTime.Now.Ticks.ToString());    // potentially helps with throttling
 
             var request = new RestRequest($"?{queryParameters}", method);
+
+            var applicationRateLimitService = context.ApplicationContext.Container.Resolve<IApplicationRateLimitingService>();
+            applicationRateLimitService.ThrottleProcessAsync(context, "DuckDuckGo_Throttling", TimeSpan.FromSeconds(1), 2, 1000).GetAwaiter().GetResult();
+
             var response = client.Execute(request);
 
             if (response.ErrorException != null)
@@ -513,7 +519,10 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             }
 
             if (response.StatusCode is HttpStatusCode.NoContent or HttpStatusCode.NotFound)
+            {
+                context.Log.LogDebug($"Duck Duck Go returned: {response.StatusCode} for {name}");
                 return null;
+            }
 
             var content = response.Content;
 
@@ -523,9 +532,11 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
                 if (responseData.Infobox != null) return responseData;
 
+                context.Log.LogDebug($"DuckDuckGo returned empty infobox for {name}");
+
                 if (response.StatusCode != HttpStatusCode.Accepted) return responseData;
 
-                System.Threading.Thread.Sleep(30000);   // sleep as we are throttled
+                throw new ApplicationException($"Too many requests - Could not execute external search query - StatusCode:{response.StatusCode}; Content: {content}");
             }
 
             throw new ApplicationException($"Could not execute external search query - StatusCode:{response.StatusCode}; Content: {content}");


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#48169](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48169)

Before throttling enricher with the application rate limit, exceptions were thrown and only a few external search queries were produced and most of them are not being enriched.

After throttling, enriching a data source with 3500 records (only 100 records have name + website) produce 3600 external search queries. 
![image](https://github.com/user-attachments/assets/5587fbeb-8a54-4eb0-a21a-9557bf5f02b8)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
