### PR TITLE
fix: Enrich using name when settings are empty

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+# Fixes
+- Enrich using name when enricher settings are empty

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -136,6 +136,10 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
                 companyWebsite = request.QueryParameters.GetValue(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.Website, new HashSet<string>()).ToHashSet();
             }
 
+            if (!string.IsNullOrEmpty(request.EntityMetaData.Name))
+                companyName.Add(request.EntityMetaData.Name);
+            if (!string.IsNullOrEmpty(request.EntityMetaData.DisplayName))
+                companyName.Add(request.EntityMetaData.DisplayName);
 
             if (companyName != null)
             {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#48799](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48799)


## How has it been tested? <!-- Remove if not needed -->
Manually in local
