### PR TITLE
feat: Add exceptions messages

### DIFF
--- a/docs/4.7.0-release-notes.md
+++ b/docs/4.7.0-release-notes.md
@@ -1,4 +1,5 @@
 # Feature
+- Added exception messages along the external search pipeline to improve clarity and logging
 
 # Fix
 - Adjusted vocabulary and vocabularyKeys method signatures to align with version 4.7.0

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -117,6 +117,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             // Query Input
             var entityType     = request.EntityMetaData.EntityType;
+            var entityName = !string.IsNullOrEmpty(request.EntityMetaData.Name) ? request.EntityMetaData.Name : request.EntityMetaData.DisplayName;
 
             var companyName    = new HashSet<string>();
             var companyWebsite = new HashSet<string>();
@@ -143,35 +144,52 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             if (!string.IsNullOrEmpty(request.EntityMetaData.DisplayName))
                 companyName.Add(request.EntityMetaData.DisplayName);
 
-            if (companyName != null)
+            if (!companyName.Any() && !companyWebsite.Any())
             {
-                var values = companyName.Select(NameNormalization.Normalize).ToHashSet();
-
-                foreach (var value in values.Where(v => !nameFilter(v) && !existingResultsFilter(v)))
-                    yield return new ExternalSearchQuery(this, entityType, ExternalSearchQueryParameter.Name, value);
+                throw new Exception($"Unable to generate queries for {entityName}. Both name and website URL are empty.");
             }
 
-            if (companyWebsite != null)
+            var values = companyName.Select(NameNormalization.Normalize).ToHashSet();
+            var filteredValues = values.Where(v => !nameFilter(v)).ToList();
+
+            if (!companyWebsite.Any() && companyName.Any() && !filteredValues.Any())
             {
-                var uriHosts = companyWebsite.Where(UriUtility.IsValid)
-                                             .Select(u => new Uri(u).Host.ToLowerInvariant())
-                                             .Distinct();
+                throw new Exception($"Unable to generate queries for {entityName}. Name is filtered out and website URL is empty.");
+            }
 
-                var domainHosts = companyWebsite.Where(v =>
-                    {
-                        if (UriUtility.IsValid(v))
-                            return false;
+            foreach (var value in filteredValues.Where(v => !existingResultsFilter(v)))
+            {
+                yield return new ExternalSearchQuery(this, entityType, ExternalSearchQueryParameter.Name, value);
+            }
 
-                        if (!DomainName.TryParse(v, out var domain))
-                            return false;
+            var filteredCompanyWebsite = companyWebsite.Where(UriUtility.IsValid).ToList();
 
-                        return true;
-                    }).Distinct();
+            if (companyWebsite.Any() && !filteredCompanyWebsite.Any() && !filteredValues.Any())
+            {
+                // Currently unable to enrich if name is empty, so this exception will not be triggered until the issue being resolved
+                throw new Exception($"Unable to generate queries for {entityName}. Name is empty. Website URL was identified as an invalid and is filtered out.");
+            }
 
-                var hosts = uriHosts.Union(domainHosts).Where(v => !existingResultsFilter2(v));
+            var uriHosts = filteredCompanyWebsite
+                    .Select(u => new Uri(u).Host.ToLowerInvariant())
+                    .Distinct();
 
-                foreach (var value in hosts)
-                    yield return new ExternalSearchQuery(this, entityType, ExternalSearchQueryParameter.Name, value);
+            var domainHosts = companyWebsite.Where(v =>
+            {
+                if (UriUtility.IsValid(v))
+                    return false;
+
+                if (!DomainName.TryParse(v, out var domain))
+                    return false;
+
+                return true;
+            }).Distinct();
+
+            var hosts = uriHosts.Union(domainHosts).Where(v => !existingResultsFilter2(v));
+
+            foreach (var value in hosts)
+            {
+                yield return new ExternalSearchQuery(this, entityType, ExternalSearchQueryParameter.Name, value);
             }
         }
 
@@ -210,11 +228,17 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
         {
             var resultItem = result.As<SearchResult>();
 
+            var entityName = !string.IsNullOrEmpty(request.EntityMetaData.Name) ? request.EntityMetaData.Name : request.EntityMetaData.DisplayName;
             if (resultItem.Data.Entity != "company")
-                yield break;
+            {
+                throw new Exception($"Unable to build clue for {entityName}. Entity is not a company.");
+            }
 
             if (string.IsNullOrEmpty(resultItem.Data.Heading))
-                yield break;
+            {
+                throw new Exception($"Unable to build clue for {entityName}. Heading is empty.");
+            }
+
             var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "duckDuckGo", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
 
             var clue = new Clue(code, context.Organization)
@@ -239,7 +263,10 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             var resultItem = result.As<SearchResult>();
 
             if (resultItem.Data.Entity != "company")
-                return null;
+            {
+                var entityName = !string.IsNullOrEmpty(request.EntityMetaData.Name) ? request.EntityMetaData.Name : request.EntityMetaData.DisplayName;
+                throw new Exception($"Unable to get metadata for {entityName}. Entity is not a company.");
+            }
 
             return this.CreateMetadata(resultItem, request, context);
         }
@@ -536,7 +563,6 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
                 if (responseData.Infobox != null) return responseData;
 
                 context.Log.LogDebug($"DuckDuckGo returned empty infobox for {name}");
-
                 if (response.StatusCode != HttpStatusCode.Accepted && response.StatusCode != HttpStatusCode.TooManyRequests) return responseData;
 
                 throw new ApplicationException($"Too many requests - Could not execute external search query - StatusCode:{response.StatusCode}; Content: {content}");

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -154,7 +154,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             if (!companyWebsite.Any() && companyName.Any() && !filteredValues.Any())
             {
-                throw new Exception($"Unable to generate queries for {entityName}. Name is filtered out and website URL is empty.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name has been filtered out and website URL is empty.");
             }
 
             foreach (var value in filteredValues.Where(v => !existingResultsFilter(v)))
@@ -166,8 +166,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             if (companyWebsite.Any() && !filteredCompanyWebsite.Any() && !filteredValues.Any())
             {
-                // Currently unable to enrich if name is empty, so this exception will not be triggered until the issue being resolved
-                throw new Exception($"Unable to generate queries for {entityName}. Name is empty. Website URL was identified as an invalid URL and is filtered out.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name either is empty or has been filtered out. Website URL was identified as an invalid URL and has been filtered out.");
             }
 
             var uriHosts = filteredCompanyWebsite

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -154,7 +154,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             if (!companyWebsite.Any() && companyName.Any() && !filteredValues.Any())
             {
-                throw new Exception($"Unable to generate queries for {entityName}. Name has been filtered out and website URL is empty.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name is filtered out and website URL is empty.");
             }
 
             foreach (var value in filteredValues.Where(v => !existingResultsFilter(v)))
@@ -166,7 +166,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             if (companyWebsite.Any() && !filteredCompanyWebsite.Any() && !filteredValues.Any())
             {
-                throw new Exception($"Unable to generate queries for {entityName}. Name either is empty or has been filtered out. Website URL was identified as an invalid URL and has been filtered out.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name either is empty or is filtered out. Website URL is invalid URL and is filtered out.");
             }
 
             var uriHosts = filteredCompanyWebsite

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -154,7 +154,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             if (!companyWebsite.Any() && companyName.Any() && !filteredValues.Any())
             {
-                throw new Exception($"Unable to generate queries for {entityName}. Name is filtered out and website URL is empty.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name has been filtered out and website URL is empty.");
             }
 
             foreach (var value in filteredValues.Where(v => !existingResultsFilter(v)))
@@ -166,7 +166,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             if (companyWebsite.Any() && !filteredCompanyWebsite.Any() && !filteredValues.Any())
             {
-                throw new Exception($"Unable to generate queries for {entityName}. Name either is empty or is filtered out. Website URL is invalid URL and is filtered out.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name either is empty or has been filtered out. Website URL is invalid URL and has been filtered out.");
             }
 
             var uriHosts = filteredCompanyWebsite

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -167,7 +167,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             if (companyWebsite.Any() && !filteredCompanyWebsite.Any() && !filteredValues.Any())
             {
                 // Currently unable to enrich if name is empty, so this exception will not be triggered until the issue being resolved
-                throw new Exception($"Unable to generate queries for {entityName}. Name is empty. Website URL was identified as an invalid and is filtered out.");
+                throw new Exception($"Unable to generate queries for {entityName}. Name is empty. Website URL was identified as an invalid URL and is filtered out.");
             }
 
             var uriHosts = filteredCompanyWebsite


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#51691](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/51691)

There are some lines detected a change but actually no changes are made. Unable to remove them by changing the line endings. 

When DuckDuckGo returned empty infobox
<img width="1920" height="798" alt="image" src="https://github.com/user-attachments/assets/22d220ea-725f-4417-9c39-281d8fed30f7" />

No results produced after evaluating the results from DuckDuckgo 
<img width="1920" height="656" alt="image" src="https://github.com/user-attachments/assets/f8a1cc8c-9d37-4ab4-aa28-6d7712b2205c" />

Name got filtered out by enricher when building queries
<img width="1918" height="604" alt="image" src="https://github.com/user-attachments/assets/d7511984-c6bf-4783-bc88-b3083ada06ae" />

DuckDuckGo enricher only wants 'company' typed infobox, so if not a company, the results will be filtered out
<img width="1918" height="636" alt="image" src="https://github.com/user-attachments/assets/62525b48-f2ee-4e6e-9315-8aeffa325a42" />


## How has it been tested? <!-- Remove if not needed -->
Manually in local
