### PR TITLE
fix: Resolve AddVocabularyKeyAsync object reference is null issue

### DIFF
--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -466,9 +466,8 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
                             IsVisible = true,
                             Storage = VocabularyKeyStorage.Keyword
                         };
-                        var vocabKeyId = vocabularyRepository.AddVocabularyKeyAsync(context, newVocabKey).GetAwaiter().GetResult();
+                        var vocabKeyId = vocabularyRepository.AddVocabularyKeyAsync(context, newVocabKey, context.Organization.Id, Guid.Empty).GetAwaiter().GetResult();
                         vocabularyRepository.ActivateVocabularyKeyAsync(context, vocabKeyId).GetAwaiter().GetResult();
-
                     }
                 }
                 else if (keyType == ResultType.Infobox)
@@ -486,7 +485,7 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
                             IsVisible = true,
                             Storage = VocabularyKeyStorage.Keyword
                         };
-                        var vocabKeyId = vocabularyRepository.AddVocabularyKeyAsync(context, newVocabKey).GetAwaiter().GetResult();
+                        var vocabKeyId = vocabularyRepository.AddVocabularyKeyAsync(context, newVocabKey, context.Organization.Id, Guid.Empty).GetAwaiter().GetResult();
                         vocabularyRepository.ActivateVocabularyKeyAsync(context, vocabKeyId).GetAwaiter().GetResult();
                     }
                 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#54203](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/54203)

Use overloaded AddVocabularyKeyAsync() that does not get UserId from context. (Missed out this change in previous PR due to package reference is not automatically pointing to latest alpha version)

No release note added in this PR because there is already one similar created before

## How has it been tested? <!-- Remove if not needed -->
Manually in local

