### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.7.0-alpha.*</_CluedIn>
-    <_ComponentHost>3.2.1</_ComponentHost>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,13 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
-    <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +23,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Integration.PrivateServices" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.DuckDuckGo.Provider/ExternalSearch.Providers.DuckDuckGo.Provider.csproj
+++ b/src/ExternalSearch.Providers.DuckDuckGo.Provider/ExternalSearch.Providers.DuckDuckGo.Provider.csproj
@@ -2,7 +2,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="CluedIn.Core" />
-		<PackageReference Include="ComponentHost" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ExternalSearch.Providers.DuckDuckGo.Provider/ExternalSearch.Providers.DuckDuckGo.Provider.csproj
+++ b/src/ExternalSearch.Providers.DuckDuckGo.Provider/ExternalSearch.Providers.DuckDuckGo.Provider.csproj
@@ -1,13 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="CluedIn.Core" />
 		<PackageReference Include="ComponentHost" />

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -199,15 +199,15 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             if (string.IsNullOrWhiteSpace(name))
                 yield break;
 
-            var client = new RestClient("https://api.duckduckgo.com")
+            var client = new RestClient(new RestClientOptions("https://api.duckduckgo.com")
             {
                 // TODO rotating the useragent can help with throttling
                 UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0"
-            };
+            });
 
             foreach (var searchName in GetSearchVariants(name.Trim()))
             {
-                var responseData = JsonRequestWrapper(context, client, searchName, Method.GET);
+                var responseData = JsonRequestWrapper(context, client, searchName, Method.Get);
 
                 if (responseData?.Infobox == null) continue;
 
@@ -299,13 +299,13 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
             queryParameters.Add("format", "json");
             queryParameters.Add("timestamp", DateTime.Now.Ticks.ToString());    // potentially helps with throttling
 
-            var request = new RestRequest($"?{queryParameters}", Method.GET);
+            var request = new RestRequest($"?{queryParameters}", Method.Get);
             var response = client.Execute(request);
 
             return ConstructVerifyConnectionResponse(response);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{DuckDuckGoConstants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/src/ExternalSearch.Providers.DuckDuckgo/ExternalSearch.Providers.DuckDuckgo.csproj
+++ b/src/ExternalSearch.Providers.DuckDuckgo/ExternalSearch.Providers.DuckDuckgo.csproj
@@ -13,7 +13,4 @@
     <PackageReference Include="CluedIn.Processing.Web" />
     <PackageReference Include="CluedIn.Processing.Web.TechnologyDetection" />
   </ItemGroup>
-  <PropertyGroup>
-	<LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.DuckDuckgo/Net/DomainName.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/Net/DomainName.cs
@@ -2,12 +2,14 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Nager.PublicSuffix;
+using Nager.PublicSuffix.Exceptions;
+using Nager.PublicSuffix.RuleProviders;
 
 namespace CluedIn.ExternalSearch.Providers.DuckDuckgo.Net;
 
 internal static class DomainName
 {
-    private static readonly DomainParser domainParser = new(new WebTldRuleProvider());
+    private static readonly DomainParser domainParser = new(new SimpleHttpRuleProvider());
 
     public static bool TryParse(string domain, [NotNullWhen(true)]out DomainInfo? domainInfo)
     {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <!-- De-comment to use xunit.core and .assert instead of the main package
          because compilation fails due to warnings triggered by xunit.analyzers.
     <PackageReference Include="xunit.core" Version="2.4.1" />


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- Nager.PublicSuffix updated to 3.x