### PR TITLE
fix: Use rate limiting from core

### DIFF
--- a/docs/4.7.1-release-notes.md
+++ b/docs/4.7.1-release-notes.md
@@ -1,2 +1,3 @@
 # Fix
 - Fix code generation by retrieving the exact query key for code generation in PopulateMetadata
+- Use rate limiting from core instead of referencing in enricher

--- a/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.DuckDuckgo/DuckDuckGoExternalSearchProvider.cs
@@ -16,7 +16,6 @@ using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Data.Vocabularies.Models;
 using CluedIn.Core.ExternalSearch;
 using CluedIn.Core.Providers;
-using CluedIn.Core.RateLimiting;
 using CluedIn.Crawling.Helpers;
 using CluedIn.ExternalSearch.Filters;
 using CluedIn.ExternalSearch.Provider;
@@ -536,14 +535,10 @@ namespace CluedIn.ExternalSearch.Providers.DuckDuckGo
 
             var request = new RestRequest($"?{queryParameters}", method);
 
-            var applicationRateLimitService = context.ApplicationContext.Container.Resolve<IApplicationRateLimitingService>();
-            applicationRateLimitService.ThrottleClusterAsync(context, "DuckDuckGo_Throttling", TimeSpan.FromSeconds(1), 5, 1000).GetAwaiter().GetResult();
-
             var response = client.Execute(request);
 
             if (response.ErrorException != null)
             {
-                System.Threading.Thread.Sleep(1000);   // sleeping as if there is an error with the remote server we don't want to burn through the queue
                 throw new ApplicationException($"Could not execute external search query - {response.ErrorException}");
             }
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#57409](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/57409)

Use the rate limiting from core instead of applying the extra one in enricher itself
<img width="1916" height="932" alt="image" src="https://github.com/user-attachments/assets/1e488834-419d-42f2-9baf-5b7aba943056" />


Related PR: https://github.com/CluedIn-io/CluedIn/pull/8200

## How has it been tested? <!-- Remove if not needed -->
Manually in local

